### PR TITLE
Sync CyberRepublic fork → canonical (API): MATIC ⇒ POL

### DIFF
--- a/tasks.ts
+++ b/tasks.ts
@@ -23,11 +23,10 @@ export type CMCResponse = {
 const tokens1: ChainIdList = {
   BTC: 1,
   BNB: 1839,
-  HT: 2502,
   AVAX: 5805,
   ETH: 1027,
   FTM: 3513,
-  MATIC: 3890,
+  POL: 28321,
   CRO: 3635,
   KAVA: 4846,
   TRX: 1958,
@@ -44,7 +43,8 @@ const tokens2: ChainIdList = {
   xDAI: 8635,
   IOTX: 2777,
   CELO: 5567,
-  USDT: 825
+  USDT: 825,
+  HT: 2502
 };
 
 // TODO: move to modules/price


### PR DESCRIPTION
Brings CyberRepublic fork work back to canonical elastos. 1 commit ahead / 0 behind — clean. Commit 9096a756 MATIC => POL. Rollback tag pre-cr-sync-2026-06-05 on master.